### PR TITLE
Removed escape sequence for character strings

### DIFF
--- a/syntaxes/poweron.language.json
+++ b/syntaxes/poweron.language.json
@@ -114,13 +114,7 @@
         "character": {
             "name": "string.quoted.double.poweron",
             "begin": "\"",
-            "end": "\"",
-            "patterns": [
-                {
-                    "name": "constant.character.escape.poweron",
-                    "match": "\\\\."
-                }
-            ]
+            "end": "\""
         },
         "comment": {
             "name": "comment.block.poweron",


### PR DESCRIPTION
This is my proposed fix for the Issue "Improper Syntax Highlighting for Escape Sequence #2"